### PR TITLE
Remove access token from store when invalid

### DIFF
--- a/lib/idsimple/rack/configuration.rb
+++ b/lib/idsimple/rack/configuration.rb
@@ -6,7 +6,7 @@ module Idsimple
     class Configuration
       DEFAULT_COOKIE_NAME = "idsimple.access_token"
 
-      attr_accessor :get_access_token, :set_access_token, :signing_secret,
+      attr_accessor :get_access_token, :set_access_token, :remove_access_token, :signing_secret,
         :authenticate_path, :issuer, :api_base_url, :after_authenticated_path,
         :app_id, :skip_on, :logger, :enabled, :unauthorized_response, :api_key,
         :redirect_to_authenticate
@@ -33,6 +33,7 @@ module Idsimple
         @api_key = nil
         @get_access_token = method(:default_access_token_getter)
         @set_access_token = method(:default_access_token_setter)
+        @remove_access_token = method(:default_access_token_remover)
         @unauthorized_response = method(:default_unauthorized_response)
         @redirect_to_authenticate = true
 
@@ -45,8 +46,10 @@ module Idsimple
         @logger = logger
       end
 
-      def default_unauthorized_response(req)
-        ["401", { "Content-Type" => "text/html" }, ["UNAUTHORIZED"]]
+      def default_unauthorized_response(req, res)
+        res.status = 401
+        res.content_type = "text/html"
+        res.body = "UNAUTHORIZED"
       end
 
       def default_access_token_getter(req)
@@ -60,6 +63,10 @@ module Idsimple
           httponly: true,
           path: "/"
         })
+      end
+
+      def default_access_token_remover(req, res)
+        res.delete_cookie(DEFAULT_COOKIE_NAME)
       end
     end
   end

--- a/lib/idsimple/rack/configuration.rb
+++ b/lib/idsimple/rack/configuration.rb
@@ -49,7 +49,7 @@ module Idsimple
       def default_unauthorized_response(req, res)
         res.status = 401
         res.content_type = "text/html"
-        res.body = "UNAUTHORIZED"
+        res.body = ["UNAUTHORIZED"]
       end
 
       def default_access_token_getter(req)

--- a/lib/idsimple/rack/helper.rb
+++ b/lib/idsimple/rack/helper.rb
@@ -16,16 +16,18 @@ module Idsimple
         configuration.signing_secret
       end
 
-      def unauthorized_response(req)
-        configuration.unauthorized_response.call(req)
+      def unauthorized_response(req, res = ::Rack::Response.new)
+        configuration.unauthorized_response.call(req, res)
+        res.finish
       end
 
-      def redirect_to_authenticate_or_unauthorized_response(req)
+      def redirect_to_authenticate_or_unauthorized_response(req, res = ::Rack::Response.new)
         if configuration.redirect_to_authenticate
           access_url = "#{configuration.issuer}/apps/#{configuration.app_id}/access?return_to=#{req.fullpath}"
-          return ["302", { "Content-Type" => "text/html", "Location" => access_url }, []]
+          res.redirect(access_url)
+          res.finish
         else
-          unauthorized_response(req)
+          unauthorized_response(req, res)
         end
       end
 
@@ -35,6 +37,10 @@ module Idsimple
 
       def set_access_token(req, res, new_access_token, new_decoded_access_token)
         configuration.set_access_token.call(req, res, new_access_token, new_decoded_access_token)
+      end
+
+      def remove_access_token(req, res)
+        configuration.remove_access_token(req, res)
       end
 
       def decode_access_token(access_token, signing_secret)

--- a/lib/idsimple/rack/helper.rb
+++ b/lib/idsimple/rack/helper.rb
@@ -40,7 +40,7 @@ module Idsimple
       end
 
       def remove_access_token(req, res)
-        configuration.remove_access_token(req, res)
+        configuration.remove_access_token.call(req, res)
       end
 
       def decode_access_token(access_token, signing_secret)

--- a/lib/idsimple/rack/validator_middleware.rb
+++ b/lib/idsimple/rack/validator_middleware.rb
@@ -64,7 +64,13 @@ module Idsimple
 
         if token_refresh_response.fail?
           logger.warn("Token refresh failed")
-          redirect_to_authenticate_or_unauthorized_response(req)
+
+          res = ::Rack::Response.new
+          if token_refresh_response.body["invalid_token"]
+            remove_access_token(req, res)
+          end
+
+          redirect_to_authenticate_or_unauthorized_response(req, res)
         else
           logger.debug("Refreshed access token")
           new_access_token = token_refresh_response.body["access_token"]


### PR DESCRIPTION
This PR adds some logic to remove the access token from the store (cookie store by default) when it's invalid. This avoids subsequent unnecessary requests to the server. In addition, I refactored the interface for `unauthorized_response` such that the block is passed a `Rack::Response` instance. This is consistent with how the other configuration blocks function (like `get_access_token` and `set_access_token`) and is needed for access token removal to work.